### PR TITLE
safeBuy buildings when store is in Sell mode

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -2174,6 +2174,22 @@ function autoGSBuy() {
     }
 }
 
+function safeBuy(bldg,count)
+{
+	var wasSell = false;
+	
+	if (Game.buyMode==-1) 
+	{
+		wasSell = true;
+		document.getElementById('storeBulkBuy').click();
+		bldg.buy(count);
+		document.getElementById('storeBulkSell').click();
+	} else {
+		bldg.buy(count);
+	}
+	
+}
+
 function autoGodzamokAction()
 {
     if (!T) return; //Just leave if Pantheon isn't here yet
@@ -2194,12 +2210,14 @@ function autoGodzamokAction()
 		
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Cursor'].amount < 10) 
 		{
-			Game.Objects['Cursor'].buy(count);
+			//Game.Objects['Cursor'].buy(count);
+			safeBuy(Game.Objects['Cursor'],count);
 		}
 		
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Farm'].amount < 10) 
 		{
-			Game.Objects['Farm'].buy(count2);
+			//Game.Objects['Farm'].buy(count2);
+			safeBuy(Game.Objects['Farm'],count2);
 		}
     }
 }
@@ -2307,8 +2325,9 @@ function autoCookie() {
             recommendation.purchase.clickFunction = null;
             disabledPopups = false;
             //      console.log(purchase.name + ': ' + Beautify(recommendation.efficiency) + ',' + Beautify(recommendation.delta_cps));
-            recommendation.purchase.buy();
-            FrozenCookies.autobuyCount += 1;
+            //recommendation.purchase.buy();
+            if (recommendation.type=='upgrade') {recommendation.purchase.buy();} else {safeBuy(recommendation.purchase);} //safebuy building
+			FrozenCookies.autobuyCount += 1;
             if (FrozenCookies.trackStats == 5 && recommendation.type == 'upgrade') {
                 saveStats();
             } else if (FrozenCookies.trackStats == 6) {

--- a/fc_main.js
+++ b/fc_main.js
@@ -2201,15 +2201,14 @@ function autoGodzamokAction()
 		{
 			var count = Game.Objects['Cursor'].amount; 	
 			Game.Objects['Cursor'].sell(count); 
-			logEvent("AutoGodzamok","Sold "+count+" cursors");
 		}
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Farm'].amount >= 10)
 		{
 			var count2 = Game.Objects['Farm'].amount-1; 	
 			Game.Objects['Farm'].sell(count2); 
-			logEvent("AutoGodzamok","Sold "+count2+" farms");
 		}
-		
+		logEvent("AutoGodzamok","Sold "+count+" cursors and "+count2+" farms");
+
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Cursor'].amount < 10) 
 		{
 			//Game.Objects['Cursor'].buy(count);

--- a/fc_main.js
+++ b/fc_main.js
@@ -2201,27 +2201,27 @@ function autoGodzamokAction()
 		{
 			var count = Game.Objects['Cursor'].amount; 	
 			Game.Objects['Cursor'].sell(count); 
-			logEvent('AutoGodzamok","Sold "+count+" cursors");
+			logEvent("AutoGodzamok","Sold "+count+" cursors");
 		}
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Farm'].amount >= 10)
 		{
 			var count2 = Game.Objects['Farm'].amount-1; 	
 			Game.Objects['Farm'].sell(count2); 
-			logEvent('AutoGodzamok","Sold "+count2+" farms");
+			logEvent("AutoGodzamok","Sold "+count2+" farms");
 		}
 		
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Cursor'].amount < 10) 
 		{
 			//Game.Objects['Cursor'].buy(count);
 			safeBuy(Game.Objects['Cursor'],count);
-			logEvent('AutoGodzamok","Re-bought "+count+" cursors");
+			logEvent("AutoGodzamok","Re-bought "+count+" cursors");
 		}
 		
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Farm'].amount < 10) 
 		{
 			//Game.Objects['Farm'].buy(count2);
 			safeBuy(Game.Objects['Farm'],count2);
-			logEvent('AutoGodzamok","Re-bought "+count2+" farms");
+			logEvent("AutoGodzamok","Re-bought "+count2+" farms");
 		}
     }
 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -2174,22 +2174,6 @@ function autoGSBuy() {
     }
 }
 
-function safeBuy(bldg,count)
-{
-	var wasSell = false;
-	
-	if (Game.buyMode==-1) 
-	{
-		wasSell = true;
-		document.getElementById('storeBulkBuy').click();
-		bldg.buy(count);
-		document.getElementById('storeBulkSell').click();
-	} else {
-		bldg.buy(count);
-	}
-	
-}
-
 function autoGodzamokAction()
 {
     if (!T) return; //Just leave if Pantheon isn't here yet
@@ -2211,14 +2195,24 @@ function autoGodzamokAction()
 
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Cursor'].amount < 10) 
 		{
+<<<<<<< HEAD
+			//Game.Objects['Cursor'].buy(count);
 			safeBuy(Game.Objects['Cursor'],count);
 			logEvent("AutoGodzamok","Re-bought "+count+" cursors");
+=======
+			Game.Objects['Cursor'].buy(count);
+>>>>>>> parent of 94767cd... Update fc_main.js
 		}
 		
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Farm'].amount < 10) 
 		{
+<<<<<<< HEAD
+			//Game.Objects['Farm'].buy(count2);
 			safeBuy(Game.Objects['Farm'],count2);
 			logEvent("AutoGodzamok","Re-bought "+count2+" farms");
+=======
+			Game.Objects['Farm'].buy(count2);
+>>>>>>> parent of 94767cd... Update fc_main.js
 		}
     }
 }
@@ -2326,9 +2320,8 @@ function autoCookie() {
             recommendation.purchase.clickFunction = null;
             disabledPopups = false;
             //      console.log(purchase.name + ': ' + Beautify(recommendation.efficiency) + ',' + Beautify(recommendation.delta_cps));
-            //recommendation.purchase.buy();
-            if (recommendation.type=='upgrade') {recommendation.purchase.buy();} else {safeBuy(recommendation.purchase);} //safebuy building
-			FrozenCookies.autobuyCount += 1;
+            recommendation.purchase.buy();
+            FrozenCookies.autobuyCount += 1;
             if (FrozenCookies.trackStats == 5 && recommendation.type == 'upgrade') {
                 saveStats();
             } else if (FrozenCookies.trackStats == 6) {

--- a/fc_main.js
+++ b/fc_main.js
@@ -2174,6 +2174,17 @@ function autoGSBuy() {
     }
 }
 
+function safeBuy(bldg,count) { 
+	// If store is in Sell mode, Game.Objects[].buy will sell the building!
+	if (Game.buyMode == -1) 
+	{
+		document.getElementById('storeBulkBuy').click();
+		bldg.buy(count);
+		document.getElementById('storeBulkSell').click();
+	} else {
+		bldg.buy(count);
+	}
+}
 
 function autoGodzamokAction()
 {
@@ -2195,11 +2206,11 @@ function autoGodzamokAction()
 		
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Cursor'].amount < 10) 
 		{
-			Game.Objects['Cursor'].buy(count);
+			safeBuy(Game.Objects['Cursor'],count);
 		}
 		if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Farm'].amount < 10) 
 		{
-			Game.Objects['Farm'].buy(count2);
+			safeBuy(Game.Objects['Farm'],count2);
 		}
     }
 }
@@ -2305,6 +2316,7 @@ function autoCookie() {
             recommendation.time = Date.now() - Game.startDate;
             //      full_history.push(recommendation);  // Probably leaky, maybe laggy?
             recommendation.purchase.clickFunction = null;
+			if (recommendation.type == 'building') { safeBuy(recommendation.purchase); } else { recommendation.purchase.buy(); }
             disabledPopups = false;
             //      console.log(purchase.name + ': ' + Beautify(recommendation.efficiency) + ',' + Beautify(recommendation.delta_cps));
             recommendation.purchase.buy();

--- a/fc_main.js
+++ b/fc_main.js
@@ -2211,14 +2211,12 @@ function autoGodzamokAction()
 
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Cursor'].amount < 10) 
 		{
-			//Game.Objects['Cursor'].buy(count);
 			safeBuy(Game.Objects['Cursor'],count);
 			logEvent("AutoGodzamok","Re-bought "+count+" cursors");
 		}
 		
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Farm'].amount < 10) 
 		{
-			//Game.Objects['Farm'].buy(count2);
 			safeBuy(Game.Objects['Farm'],count2);
 			logEvent("AutoGodzamok","Re-bought "+count2+" farms");
 		}

--- a/fc_main.js
+++ b/fc_main.js
@@ -2201,23 +2201,27 @@ function autoGodzamokAction()
 		{
 			var count = Game.Objects['Cursor'].amount; 	
 			Game.Objects['Cursor'].sell(count); 
+			logEvent('AutoGodzamok","Sold "+count+" cursors");
 		}
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Farm'].amount >= 10)
 		{
 			var count2 = Game.Objects['Farm'].amount-1; 	
 			Game.Objects['Farm'].sell(count2); 
+			logEvent('AutoGodzamok","Sold "+count2+" farms");
 		}
 		
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Cursor'].amount < 10) 
 		{
 			//Game.Objects['Cursor'].buy(count);
 			safeBuy(Game.Objects['Cursor'],count);
+			logEvent('AutoGodzamok","Re-bought "+count+" cursors");
 		}
 		
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Farm'].amount < 10) 
 		{
 			//Game.Objects['Farm'].buy(count2);
 			safeBuy(Game.Objects['Farm'],count2);
+			logEvent('AutoGodzamok","Re-bought "+count2+" farms");
 		}
     }
 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -2176,18 +2176,14 @@ function autoGSBuy() {
 
 function safeBuy(bldg,count)
 {
-	var wasSell = false;
-	
 	if (Game.buyMode==-1) 
 	{
-		wasSell = true;
 		document.getElementById('storeBulkBuy').click();
 		bldg.buy(count);
 		document.getElementById('storeBulkSell').click();
 	} else {
 		bldg.buy(count);
 	}
-	
 }
 
 function autoGodzamokAction()
@@ -2207,18 +2203,13 @@ function autoGodzamokAction()
 			var count2 = Game.Objects['Farm'].amount-1; 	
 			Game.Objects['Farm'].sell(count2); 
 		}
-		logEvent("AutoGodzamok","Sold "+count+" cursors and "+count2+" farms");
-
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Cursor'].amount < 10) 
 		{
 			safeBuy(Game.Objects['Cursor'],count);
-			logEvent("AutoGodzamok","Re-bought "+count+" cursors");
 		}
-		
-        if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Farm'].amount < 10) 
+		if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Farm'].amount < 10) 
 		{
 			safeBuy(Game.Objects['Farm'],count2);
-			logEvent("AutoGodzamok","Re-bought "+count2+" farms");
 		}
     }
 }
@@ -2327,7 +2318,7 @@ function autoCookie() {
             disabledPopups = false;
             //      console.log(purchase.name + ': ' + Beautify(recommendation.efficiency) + ',' + Beautify(recommendation.delta_cps));
             //recommendation.purchase.buy();
-            if (recommendation.type=='upgrade') {recommendation.purchase.buy();} else {safeBuy(recommendation.purchase);} //safebuy building
+            if (recommendation.type != 'building') {recommendation.purchase.buy();} else {safeBuy(recommendation.purchase);} //safebuy building
 			FrozenCookies.autobuyCount += 1;
             if (FrozenCookies.trackStats == 5 && recommendation.type == 'upgrade') {
                 saveStats();

--- a/fc_main.js
+++ b/fc_main.js
@@ -2191,28 +2191,15 @@ function autoGodzamokAction()
 			var count2 = Game.Objects['Farm'].amount-1; 	
 			Game.Objects['Farm'].sell(count2); 
 		}
-		logEvent("AutoGodzamok","Sold "+count+" cursors and "+count2+" farms");
-
+		
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Cursor'].amount < 10) 
 		{
-<<<<<<< HEAD
-			//Game.Objects['Cursor'].buy(count);
-			safeBuy(Game.Objects['Cursor'],count);
-			logEvent("AutoGodzamok","Re-bought "+count+" cursors");
-=======
 			Game.Objects['Cursor'].buy(count);
->>>>>>> parent of 94767cd... Update fc_main.js
 		}
 		
         if ((FrozenCookies.autoGodzamok >= 1) && Game.Objects['Farm'].amount < 10) 
 		{
-<<<<<<< HEAD
-			//Game.Objects['Farm'].buy(count2);
-			safeBuy(Game.Objects['Farm'],count2);
-			logEvent("AutoGodzamok","Re-bought "+count2+" farms");
-=======
 			Game.Objects['Farm'].buy(count2);
->>>>>>> parent of 94767cd... Update fc_main.js
 		}
     }
 }


### PR DESCRIPTION
In current version of Cookie Clicker (2.029), Game.Objects[].buy() will actually sell buildings if the store is in sell mode.  Since buildings get more efficient when you sell them, this will usually cause FC to sell all of that building type as it keeps trying to autobuy them.  The safeBuy() function makes sure the store is in buy mode before trying to buy a building.  