### PR TITLE
Remove extra Godzamok prefs

### DIFF
--- a/fc_preferences.js
+++ b/fc_preferences.js
@@ -106,8 +106,8 @@ FrozenCookies.preferenceValues = {
         'default': 0
     },
     'autoGodzamok': {
-        'hint': 'Automatically sell all cursors and farms (except one) during Dragonflight and Click Frenzy if you worship Godzamok ("Sane" prevents rapid buy/sell spam)',
-        'display': ['Auto-Godzamok OFF', 'Auto-Godzamok ON', 'Auto-Godzamok ON (Sane)', 'Auto-Godzamok ON (REALLY INSANE)'],
+        'hint': 'Automatically sell all cursors and farms (except one) during Dragonflight and Click Frenzy if you worship Godzamok',
+        'display': ['Auto-Godzamok OFF', 'Auto-Godzamok ON'],
         'default': 0
     },
     'autoSpell': {


### PR DESCRIPTION
426c3b34b33339604b1aa45fe0e2fc4686a95eb7 made it so these all have the same effect.

Question: if the pref is saved at 2 or 3, will deleting these cause a problem?