### PR TITLE
autoBulkBuy fixes; update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ What can Frozen Cookies do?
 What's new?
 -----------
 
+2020 Oct 26
+ - Version 1.9.0
+ - Fix Autoascend number entry. ([Issue #49](https://github.com/Mtarnuhal/FrozenCookies/pull/49))
+ - Fix recommendation list to show accurate efficiency percentages even when auto-buy excludes the purchase of some buildings (like when they've hit their max). ([Issue #47](https://github.com/Mtarnuhal/FrozenCookies/pull/47))
+ - Simplified autoGodzamok: Now just on or off. When on, it will wait until Dragonflight or Click Frenzy and sell all the cursors and farms to get the Devastation buff. Then, if auto-buy is turned on, it will immediately buy the buildings back (stopping at the max for those buildings if a max has been set).
+ - Fix auto-harvest of sugar lump. ([Issue #18](https://github.com/Mtarnuhal/FrozenCookies/pull/18))
+ - Show correct buff value on Devastation tooltip, even if additional buildings have been sold after the buff has started. ([Issue #46](https://github.com/Mtarnuhal/FrozenCookies/pull/46))
+ - Other minor fixes
+
 2020 Sept 28
  - Version  1.8.0
  - Move preferences to their own file

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ What's new?
 
 2020 Oct 26
  - Version 1.9.0
- - Fix Autoscend number entry. ([Issue #49](https://github.com/Mtarnuhal/FrozenCookies/pull/49))
+ - Fix autoAscend number entry. ([Issue #49](https://github.com/Mtarnuhal/FrozenCookies/pull/49))
  - Fix recommendation list to show accurate efficiency percentages even when AutoBuy excludes the purchase of some buildings (like when they've hit their max). ([Issue #47](https://github.com/Mtarnuhal/FrozenCookies/pull/47))
  - Simplified Auto-Godzamok: Now just on or off. When on, it will wait until Dragonflight or Click Frenzy and sell all the cursors and farms to get the Devastation buff. Then, if AutoBuy is turned on, it will immediately buy the buildings back (stopping at the max for those buildings if a max has been set).
  - Fix autoharvest of sugar lump. ([Issue #18](https://github.com/Mtarnuhal/FrozenCookies/pull/18))

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ What's new?
 
 2020 Oct 26
  - Version 1.9.0
- - Fix Autoascend number entry. ([Issue #49](https://github.com/Mtarnuhal/FrozenCookies/pull/49))
- - Fix recommendation list to show accurate efficiency percentages even when auto-buy excludes the purchase of some buildings (like when they've hit their max). ([Issue #47](https://github.com/Mtarnuhal/FrozenCookies/pull/47))
- - Simplified autoGodzamok: Now just on or off. When on, it will wait until Dragonflight or Click Frenzy and sell all the cursors and farms to get the Devastation buff. Then, if auto-buy is turned on, it will immediately buy the buildings back (stopping at the max for those buildings if a max has been set).
- - Fix auto-harvest of sugar lump. ([Issue #18](https://github.com/Mtarnuhal/FrozenCookies/pull/18))
+ - Fix Autoscend number entry. ([Issue #49](https://github.com/Mtarnuhal/FrozenCookies/pull/49))
+ - Fix recommendation list to show accurate efficiency percentages even when AutoBuy excludes the purchase of some buildings (like when they've hit their max). ([Issue #47](https://github.com/Mtarnuhal/FrozenCookies/pull/47))
+ - Simplified Auto-Godzamok: Now just on or off. When on, it will wait until Dragonflight or Click Frenzy and sell all the cursors and farms to get the Devastation buff. Then, if AutoBuy is turned on, it will immediately buy the buildings back (stopping at the max for those buildings if a max has been set).
+ - Fix autoharvest of sugar lump. ([Issue #18](https://github.com/Mtarnuhal/FrozenCookies/pull/18))
  - Show correct buff value on Devastation tooltip, even if additional buildings have been sold after the buff has started. ([Issue #46](https://github.com/Mtarnuhal/FrozenCookies/pull/46))
+ - Fix Auto Bulkbuy to only actually kick in after a reincarnation instead of all the time.
  - Other minor fixes
 
 2020 Sept 28
@@ -63,8 +64,8 @@ What's new?
 2018 Oct 27
 - Added Shimmering veil blacklists
 - Updated SE auto cast strategy to use new fractal engine instead of chancemaker.
-- Added farms to godzamok sold buildings as they contribute barely synergy. sells all farms except 1 for the garden. added a new option to limit farms just like cursors
-- Added Fractal engine reletaded upgrade values
+- Added farms to godzamok sold buildings as they contribute barely synergy. Sells all farms except 1 for the garden. Added a new option to limit farms just like cursors
+- Added Fractal engine related upgrade values
 
 2018 Aug 6
 - New "Harvest Bank" option to select a higher Bank than for Frenzy/Clicking Frenzy if you want to get the maximum return from harvesting Bakeberries, Chocoroots, White Chocoroots, Queenbeets or Duketaters

--- a/fc_main.js
+++ b/fc_main.js
@@ -47,6 +47,7 @@ function setOverrides() {
     FrozenCookies.lastHCTime = Number(localStorage.getItem('lastHCTime'));
     FrozenCookies.prevLastHCTime = Number(localStorage.getItem('prevLastHCTime'));
     FrozenCookies.maxHCPercent = Number(localStorage.getItem('maxHCPercent'));
+    FrozenCookies.autoBulkReady = Number(localStorage.getItem('autoBulkReady'));
 
     // Set default values for calculations
     FrozenCookies.hc_gain = 0;
@@ -103,7 +104,8 @@ function setOverrides() {
         return timeDisplay(time / Game.fps);
     }
     Game.tooltip.oldDraw = Game.tooltip.draw;
-    Game.tooltip.draw = fcDraw; Game.oldReset = Game.Reset;
+    Game.tooltip.draw = fcDraw;
+    Game.oldReset = Game.Reset;
     Game.oldWriteSave = Game.WriteSave;
     Game.oldLoadSave = Game.LoadSave;
     Game.Reset = fcReset;
@@ -328,6 +330,7 @@ function fcReset() {
     FrozenCookies.lastCps = 0;
     FrozenCookies.lastBaseCps = 0;
     FrozenCookies.trackedStats = [];
+    FrozenCookies.autoBulkReady = 1;
     updateLocalStorage();
     recommendationList(true);
 }
@@ -359,6 +362,7 @@ function updateLocalStorage() {
     localStorage.manaMax = FrozenCookies.manaMax;
     localStorage.maxSpecials = FrozenCookies.maxSpecials;
     localStorage.prevLastHCTime = FrozenCookies.prevLastHCTime;
+    localStorage.autoBulkReady = FrozenCookies.autoBulkReady;
 }
 
 function divCps(value, cps) {
@@ -2289,15 +2293,17 @@ function autoCookie() {
         }
 
         var itemBought = false;
+
         //Automatically buy in bulk if setting turned on
-        if (FrozenCookies.autoBulk != 0){
-            if (FrozenCookies.autoBulk == 1){ //Buy x10
+        if (FrozenCookies.autoBulkReady && FrozenCookies.autoBulk != 0) {
+            if (FrozenCookies.autoBulk == 1) { // Buy x10
                 document.getElementById('storeBulk10').click();
             }
-            if (FrozenCookies.autoBulk == 2){ //Buy x100
+            if (FrozenCookies.autoBulk == 2) { // Buy x100
                 document.getElementById('storeBulk100').click();
             }
-        }         
+            FrozenCookies.autoBulkReady = 0;
+        }       
         
         //var seConditions = (Game.cookies >= delay + recommendation.cost) || (!(FrozenCookies.autoSpell == 3) && !(FrozenCookies.holdSEBank))); //true == good on SE bank or don't care about it
         if (FrozenCookies.autoBuy && ((Game.cookies >= delay + recommendation.cost) || recommendation.purchase.name == "Elder Pledge") && (FrozenCookies.pastemode || isFinite(nextChainedPurchase().efficiency))) {

--- a/frozen_cookies.js
+++ b/frozen_cookies.js
@@ -8,7 +8,7 @@ var baseUrl = scriptElement !== null ?
 var FrozenCookies = {
     'baseUrl': baseUrl,
     'branch': '',
-    'version': '1.8.1'
+    'version': '1.9.0'
 };
 
 // Load external libraries

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frozencookies",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "description": "An automated Cookie Clicker tool.",
   "main": "frozen_cookie.js",
   "repository": {


### PR DESCRIPTION
autoBulk was just turning on the bulk buy all the time, and therefore wasn't very useful. This now sets a variable that persists across ascensions to determine if the game has ascended or not. If it has, only then is the bulk buy turned on.

Also, updated the readme and version strings.