### PR TITLE
Patch auto bulkbuy

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -2303,6 +2303,7 @@ function autoCookie() {
                 document.getElementById('storeBulk100').click();
             }
             FrozenCookies.autoBulkReady = 0;
+            updateLocalStorage();
         }       
         
         //var seConditions = (Game.cookies >= delay + recommendation.cost) || (!(FrozenCookies.autoSpell == 3) && !(FrozenCookies.holdSEBank))); //true == good on SE bank or don't care about it


### PR DESCRIPTION
Wanted to make extra sure that what was happening in game was kept in sync with what was saved so as to prevent an issue where a user resets their building buy function to 1x, but reloads the game before they ascend next and finds the buy function has returned to 100x.