### PR TITLE
fix autoGodzamokAction

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -2184,25 +2184,16 @@ function autoGodzamokAction() {
 			var countF = Game.Objects['Farm'].amount-1;
 
 			//Automatically sell all cursors and farms (except one) during Dragonflight and Click Frenzy if you worship Godzamok and prevent rapid buy/sell spam
-			if ( ( FrozenCookies.autoGodzamok >= 1 ) && hasClickBuff() && !Game.hasBuff('Devastation') ) {
-				Game.Objects['Cursor'].sell( countC );
-				Game.Objects['Farm'].sell( countF );
-
-				if ( FrozenCookies.autoBuy == 1 ) {
-					if ( ( FrozenCookies.cursorLimit ) && countC > FrozenCookies.cursorMax ) {
-						safeBuy( Game.Objects['Cursor'], FrozenCookies.cursorMax );
-						logEvent( "AutoGodzamok", "Bought " + FrozenCookies.cursorMax + " cursors" );
-					} else {
-						safeBuy( Game.Objects['Cursor'], countC );
-						logEvent( "AutoGodzamok", "Bought " + countC + " cursors" );
-					}
-					if ( ( FrozenCookies.farmLimit ) && countF > ( FrozenCookies.farmMax - 1 ) )  {
-						safeBuy( Game.Objects['Farm'], FrozenCookies.farmMax - 1 );
-						logEvent( "AutoGodzamok", "Bought " + ( FrozenCookies.farmMax - 1 ) + " farms" );
-					} else {
-						safeBuy( Game.Objects['Farm'], countF );
-						logEvent( "AutoGodzamok", "Bought " + countF + " farms" );
-					}
+			if (hasClickBuff() && !Game.hasBuff('Devastation')) {
+				if (countC > 0) {
+					Game.Objects['Cursor'].sell(countC);
+					safeBuy(Game.Objects['Cursor'], countC);
+					logEvent("AutoGodzamok", "Bought " + countC + " cursors");
+				}
+				if (countF > 0) {
+					Game.Objects['Farm'].sell(countF);
+					safeBuy(Game.Objects['Farm'], countF);
+					logEvent("AutoGodzamok", "Bought " + countF + " farms");
 				}
 			}
 		}

--- a/fc_main.js
+++ b/fc_main.js
@@ -2187,11 +2187,13 @@ function autoGodzamokAction() {
 			if (hasClickBuff() && !Game.hasBuff('Devastation')) {
 				if (countC > 0) {
 					Game.Objects['Cursor'].sell(countC);
-					safeBuy(Game.Objects['Cursor'], countC);
-					logEvent("AutoGodzamok", "Bought " + countC + " cursors");
 				}
 				if (countF > 0) {
 					Game.Objects['Farm'].sell(countF);
+				}
+				if (FrozenCookies.autoBuyBack) {
+					safeBuy(Game.Objects['Cursor'], countC);
+					logEvent("AutoGodzamok", "Bought " + countC + " cursors");
 					safeBuy(Game.Objects['Farm'], countF);
 					logEvent("AutoGodzamok", "Bought " + countF + " farms");
 				}

--- a/fc_preferences.js
+++ b/fc_preferences.js
@@ -110,6 +110,11 @@ FrozenCookies.preferenceValues = {
         'display': ['Auto-Godzamok OFF', 'Auto-Godzamok ON'],
         'default': 0
     },
+    'autoBuyBack': {
+        'hint': 'Automatically buy back same number of units when you sold buildings by autoGodzamok',
+        'display': ['Auto-BuyBack OFF', 'Auto-BuyBack ON'],
+        'default': 0
+    },
     'autoSpell': {
         'hint': 'Automatically cast selected spell when your mana is full',
         'display': ["Auto Cast OFF","Auto Cast CONJURE BAKED GOODS", "Auto Cast FORCE THE HAND OF FATE","Auto Cast SPONTANEOUS EDIFICE","Auto Cast HAGGLER'S CHARM (cheapest)"],


### PR DESCRIPTION
In the current implementation, autoGodzamokAction will not buy back unless autoBuy is enabled.
However, if you enabled autoBuy, you will buying other buildings more than just buying back.
This will not store cookies in Bank.

In some cases, you mayget more CpS if you buy Upgrades with storing cookies than if you buy buildings.
In this situation, feels very inconvenient.

For that reason, I want to return the behavior of only buy back like before.
