### PR TITLE
fix for https://github.com/Mtarnuhal/FrozenCookies/issues/89

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -1473,7 +1473,7 @@ function upgradeStats(recalculate) {
             FrozenCookies.caches.upgrades = [];
         } else {
             var upgradeBlacklist = blacklist[FrozenCookies.blacklist].upgrades;
-            FrozenCookies.caches.upgrades = Game.UpgradesById.map(function (current) {
+            FrozenCookies.caches.upgrades = (Game.UpgradesById.map||Object.values(Game.UpgradesById).map)(function (current) {
                 if (!current.bought) {
                     if (isUnavailable(current, upgradeBlacklist)) {
                         return null;


### PR DESCRIPTION
Error appears to be caused by a change to the type of `Game.UpgradesById`

```
> typeof(Game.UpgradesById)
< 'object'
```

Use map function if available, otherwise assume it is an object